### PR TITLE
SendMessage does not work using official aws-sdk for Nodejs

### DIFF
--- a/lib/fake_sqs/web_interface.rb
+++ b/lib/fake_sqs/web_interface.rb
@@ -30,6 +30,11 @@ module FakeSQS
     end
 
     post "/" do
+      if params['QueueUrl']
+        queue = URI.parse(params['QueueUrl']).path.gsub(/\//, '')
+        return settings.api.call(action, queue, params) unless queue.empty?
+      end
+
       settings.api.call(action, params)
     end
 


### PR DESCRIPTION
aws-sdk for ruby POST the SendMessage action to the **/:queue_name** path but NodeJS npm (official) POST the SendMessage action to the root path "/" and obtain the queue name from the QueueUrl parameter

It seems that the Amazon API support both so I've hacked the code to workaround it. 

Could you please merge the pull request and publish the gem again?

thanks in advance
