### PR TITLE
ReceiveMessage should put MD5 in tag MD5OfBody instead of MD5OfMessageBody

### DIFF
--- a/lib/fake_sqs/actions/receive_message.rb
+++ b/lib/fake_sqs/actions/receive_message.rb
@@ -16,7 +16,7 @@ module FakeSQS
             xml.Message do
               xml.MessageId message.id
               xml.ReceiptHandle receipt
-              xml.MD5OfMessageBody message.md5
+              xml.MD5OfBody message.md5
               xml.Body message.body
             end
           end


### PR DESCRIPTION
This fixes #3
