### PR TITLE
SendMessage should work even if request does not include queue name in u...

### DIFF
--- a/lib/fake_sqs/web_interface.rb
+++ b/lib/fake_sqs/web_interface.rb
@@ -30,6 +30,11 @@ module FakeSQS
     end
 
     post "/" do
+      if params['QueueUrl']
+        queue = URI.parse(params['QueueUrl']).path.gsub(/\//, '')
+        return settings.api.call(action, queue, params) unless queue.empty?
+      end
+
       settings.api.call(action, params)
     end
 


### PR DESCRIPTION
Both @jpgarcia's fork and @iain's original were throwing errors for me that SQS itself was not. I pull @jpgarcia's fork, rebased against @iain's to bring it up to date, and everything's working swimmingly now.
