### PR TITLE
Make database optional for the test_integration.

### DIFF
--- a/lib/fake_sqs/test_integration.rb
+++ b/lib/fake_sqs/test_integration.rb
@@ -23,7 +23,7 @@ module FakeSQS
     end
 
     def start!
-      args = [ binfile, "-p", port.to_s, verbose, logging, "--database", database, { :out => out, :err => out } ].flatten.compact
+      args = [ binfile, "-p", port.to_s, verbose, database, logging, { :out => out, :err => out } ].flatten.compact
       @pid = Process.spawn(*args)
       wait_until_up
     end
@@ -36,6 +36,15 @@ module FakeSQS
       else
         $stderr.puts "FakeSQS is not running"
       end
+    end
+
+    def database
+      if options.has_key? :database
+        ["--database", options.fetch(:database)]
+      else
+        []
+      end
+
     end
 
     def reset
@@ -60,10 +69,6 @@ module FakeSQS
 
     def option(key)
       options.fetch(key) { AWS.config.public_send(key) }
-    end
-
-    def database
-      options.fetch(:database)
     end
 
     def verbose


### PR DESCRIPTION
We are using this in integration tests and would prefer it used the in-memory store rather than a file store.
