### PR TITLE
Fixes for a couple of crashes when running fake_sqs standalone

### DIFF
--- a/lib/fake_sqs/error_response.rb
+++ b/lib/fake_sqs/error_response.rb
@@ -16,7 +16,7 @@ module FakeSQS
     end
 
     def body
-      xml = Builder::XmlMarkup.new(:index => 4)
+      xml = Builder::XmlMarkup.new()
       xml.ErrorResponse do
         xml.Error do
           xml.Type type

--- a/lib/fake_sqs/queue.rb
+++ b/lib/fake_sqs/queue.rb
@@ -1,3 +1,4 @@
+require 'monitor'
 require 'securerandom'
 require 'fake_sqs/collection_view'
 

--- a/lib/fake_sqs/responder.rb
+++ b/lib/fake_sqs/responder.rb
@@ -5,7 +5,7 @@ module FakeSQS
   class Responder
 
     def call(name, &block)
-      xml = Builder::XmlMarkup.new(:indent => 4)
+      xml = Builder::XmlMarkup.new()
       xml.tag! "#{name}Response" do
         if block
           xml.tag! "#{name}Result" do

--- a/lib/fake_sqs/web_interface.rb
+++ b/lib/fake_sqs/web_interface.rb
@@ -30,7 +30,7 @@ module FakeSQS
     end
 
     post "/" do
-      params['logger'] = logger
+      #params['logger'] = logger
       if params['QueueUrl']
         queue = URI.parse(params['QueueUrl']).path.gsub(/\//, '')
         return settings.api.call(action, queue, params) unless queue.empty?


### PR DESCRIPTION
When running the standalone fake_sqs and attempting to create a new queue, we hit a couple of crashes:

The first was a reference to undefined 'logger'.

The second was a reference to undefined 'Monitor'.
