### PR TITLE
Respond to both GET and POST

### DIFF
--- a/fake_sqs.gemspec
+++ b/fake_sqs.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "rspec"
   gem.add_development_dependency "rake"
+  gem.add_development_dependency "rack-test"
   gem.add_development_dependency "aws-sdk"
   gem.add_development_dependency "faraday"
   gem.add_development_dependency "thin"

--- a/lib/fake_sqs/test_integration.rb
+++ b/lib/fake_sqs/test_integration.rb
@@ -51,7 +51,7 @@ module FakeSQS
     end
 
     def up?
-      @pid && connection.get("/").code.to_s == "200"
+      @pid && connection.get("/ping").code.to_s == "200"
     rescue Errno::ECONNREFUSED
       false
     end

--- a/lib/fake_sqs/web_interface.rb
+++ b/lib/fake_sqs/web_interface.rb
@@ -5,20 +5,20 @@ require 'fake_sqs/error_response'
 module FakeSQS
   class WebInterface < Sinatra::Base
 
+    def self.handle(path, verbs, &block)
+      verbs.each do |verb|
+        send(verb, path, &block)
+      end
+    end
+
     configure do
       use FakeSQS::CatchErrors, response: ErrorResponse
     end
 
     helpers do
-
       def action
         params.fetch("Action")
       end
-
-    end
-
-    get "/" do
-      200
     end
 
     get "/ping" do
@@ -35,7 +35,7 @@ module FakeSQS
       200
     end
 
-    post "/" do
+    handle "/", [:get, :post] do
       params['logger'] = logger
       if params['QueueUrl']
         queue = URI.parse(params['QueueUrl']).path.gsub(/\//, '')
@@ -45,9 +45,8 @@ module FakeSQS
       settings.api.call(action, params)
     end
 
-    post "/:queue" do |queue|
+    handle "/:queue", [:get, :post] do |queue|
       settings.api.call(action, queue, params)
     end
-
   end
 end

--- a/lib/fake_sqs/web_interface.rb
+++ b/lib/fake_sqs/web_interface.rb
@@ -1,4 +1,6 @@
 require 'sinatra/base'
+require 'fake_sqs/catch_errors'
+require 'fake_sqs/error_response'
 
 module FakeSQS
   class WebInterface < Sinatra::Base
@@ -16,6 +18,10 @@ module FakeSQS
     end
 
     get "/" do
+      200
+    end
+
+    get "/ping" do
       200
     end
 

--- a/spec/unit/web_interface_spec.rb
+++ b/spec/unit/web_interface_spec.rb
@@ -1,0 +1,15 @@
+require 'fake_sqs/web_interface'
+require 'rack/test'
+
+describe FakeSQS::WebInterface do
+  include Rack::Test::Methods
+
+  def app
+    FakeSQS::WebInterface
+  end
+
+  it "responds to GET /ping" do
+    get "/ping"
+    expect(last_response).to be_ok
+  end
+end


### PR DESCRIPTION
According to [the docs](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/MakingRequests_MakingQueryRequestsArticle.html), SQS accepts both GET and POST requests. This small PR expands the existing POST handlers to do that. I also added a `/ping` handler to test whether the service is up, since `GET /` is no longer a valid request (because the Action parameter is required).
