### PR TITLE
Support Message Attributes

### DIFF
--- a/lib/fake_sqs/actions/receive_message.rb
+++ b/lib/fake_sqs/actions/receive_message.rb
@@ -18,6 +18,16 @@ module FakeSQS
               xml.ReceiptHandle receipt
               xml.MD5OfBody message.md5
               xml.Body message.body
+              message.message_attributes.each do |attribute|
+                xml.MessageAttribute do
+                  xml.Name attribute["Name"]
+                  xml.Value do
+                    xml.StringValue attribute["Value.StringValue"] if attribute["Value.StringValue"]
+                    xml.BinaryValue attribute["Value.BinaryValue"] if attribute["Value.BinaryValue"]
+                    xml.DataType attribute["Value.DataType"]
+                  end
+                end
+              end
             end
           end
         end

--- a/lib/fake_sqs/message.rb
+++ b/lib/fake_sqs/message.rb
@@ -3,13 +3,14 @@ require 'securerandom'
 module FakeSQS
   class Message
 
-    attr_reader :body, :id, :md5
+    attr_reader :body, :id, :md5, :message_attributes
     attr_accessor :visibility_timeout
 
     def initialize(options = {})
       @body = options.fetch("MessageBody")
       @id = options.fetch("Id") { SecureRandom.uuid }
       @md5 = options.fetch("MD5") { Digest::MD5.hexdigest(@body) }
+      @message_attributes = extract_attributes(options)
     end
 
     def expire!
@@ -29,6 +30,18 @@ module FakeSQS
         "MessageBody" => body,
         "Id" => id,
         "MD5" => md5,
+      }
+    end
+
+    private
+    def extract_attributes(options)
+      attributes = []
+      options.each {|key, value|
+        if /MessageAttribute\.(?<attr_index>\d+)\.(?<attr_name>.*)/ =~ key
+          index = attr_index.to_i - 1
+          attributes[index] = Hash.new unless attributes[index]
+          attributes[index][attr_name] = value
+        end
       }
     end
 


### PR DESCRIPTION
This change supports message attributes by pulling them out of the request headers and storing them in the message object.

The receive action will generate the XML for any attributes stored on the message body.