### PR TITLE
Removed indentation in XML responses in order to work with aws-sdk v2

### DIFF
--- a/lib/fake_sqs/responder.rb
+++ b/lib/fake_sqs/responder.rb
@@ -5,7 +5,7 @@ module FakeSQS
   class Responder
 
     def call(name, &block)
-      xml = Builder::XmlMarkup.new(:indent => 4)
+      xml = Builder::XmlMarkup.new
       xml.tag! "#{name}Response" do
         if block
           xml.tag! "#{name}Result" do


### PR DESCRIPTION
Indentation in the XML responses does not work with aws-sdk v2, when the default XML parser - REXML is used.
