### PR TITLE
returns existing queue if exist

### DIFF
--- a/lib/fake_sqs/queues.rb
+++ b/lib/fake_sqs/queues.rb
@@ -14,12 +14,9 @@ module FakeSQS
     end
 
     def create(name, options = {})
-      if database[name]
-        fail QueueNameExists, name
-      else
-        queue = queue_factory.new(options)
-        database[name] = queue
-      end
+      return database[name] if database[name]
+      queue = queue_factory.new(options)
+      database[name] = queue
     end
 
     def delete(name, options = {})

--- a/spec/unit/queues_spec.rb
+++ b/spec/unit/queues_spec.rb
@@ -27,11 +27,9 @@ RSpec.describe FakeSQS::Queues do
       expect(create_queue("test")).to eq queue
     end
 
-    it "cannot create a queue with the same name" do
-      create_queue("test")
-      expect {
-        create_queue("test")
-      }.to raise_error(FakeSQS::QueueNameExists, "test")
+    it "returns existing queue if the queue exists" do
+      queue = create_queue("test")
+      expect(create_queue("test")).to eq(queue)
     end
 
   end


### PR DESCRIPTION
According to the documentation:

https://docs.aws.amazon.com/AWSRubySDK/latest/AWS/SQS/QueueCollection.html#create-instance_method

"The name of the queue should be unique within your account. If you provide the name of an existing queue with the same options it was created with then no error is raised and the existing queue will be returned."