### PR TITLE
Update instructions to v2 of the AWS SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,8 +159,10 @@ Now you can use the `:sqs metadata to enable SQS integration:
 
 ``` ruby
 describe "something with sqs", :sqs do
-  it "should work" do
-    queue = Aws::SQS::Client.new(region: 'us-east-1').create_queue({queue_name: "my-queue"})
+  it "creates a queue called 'my-queue'" do
+    client = Aws::SQS::Client.new(region: 'us-east-1')
+    client.config.endpoint = $fake_sqs.uri
+    client.create_queue({queue_name: "my-queue"})
   end
 end
 ```


### PR DESCRIPTION
I recently set up fake SQS for my own project, and I had to do some research on how the setup should look like with the new version of the AWS SDK. I just updated the instructions so that they should work for the current version.
