### PR TITLE
Implement API action ListDeadLetterSourceQueues

### DIFF
--- a/lib/fake_sqs/actions/list_dead_letter_source_queues.rb
+++ b/lib/fake_sqs/actions/list_dead_letter_source_queues.rb
@@ -1,0 +1,25 @@
+module FakeSQS
+  module Actions
+    class ListDeadLetterSourceQueues
+
+      def initialize(options = {})
+        @server    = options.fetch(:server)
+        @queues    = options.fetch(:queues)
+        @responder = options.fetch(:responder)
+      end
+
+      def call(name, params)
+        queue_arn = @queues.get(name).arn
+        queue_urls = @queues.list.select do |queue|
+          redrive_policy = queue.attributes.fetch("RedrivePolicy", nil)
+          redrive_policy && redrive_policy =~ /deadLetterTargetArn\":\"#{queue_arn}/
+        end
+        @responder.call :ListDeadLetterSourceQueues do |xml|
+          queue_urls.each do |queue|
+            xml.QueueUrl @server.url_for(queue.name)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fake_sqs/api.rb
+++ b/lib/fake_sqs/api.rb
@@ -11,6 +11,7 @@ require 'fake_sqs/actions/purge_queue'
 require 'fake_sqs/actions/send_message_batch'
 require 'fake_sqs/actions/get_queue_attributes'
 require 'fake_sqs/actions/set_queue_attributes'
+require 'fake_sqs/actions/list_dead_letter_source_queues'
 
 module FakeSQS
 


### PR DESCRIPTION
Implement API action [ListDeadLetterSourceQueues](http://docs.aws.amazon.com/sdkforruby/api/Aws/SQS/Client.html#list_dead_letter_source_queues-instance_method)
