### PR TITLE
Accept visibility_timeout as a parameter for receive_message API call

### DIFF
--- a/lib/fake_sqs/api.rb
+++ b/lib/fake_sqs/api.rb
@@ -27,7 +27,7 @@ module FakeSQS
       @timer     = Thread.new do
         while @run_timer
           queues.timeout_messages!
-          sleep(5)
+          sleep(1)
         end
       end
     end

--- a/lib/fake_sqs/queue.rb
+++ b/lib/fake_sqs/queue.rb
@@ -65,7 +65,7 @@ module FakeSQS
 
         actual_amount.times do
           message = @messages.delete_at(rand(size))
-          message.expire_at(default_visibility_timeout)
+          message.expire_at(Integer options.fetch("VisibilityTimeout") {default_visibility_timeout} )
           receipt = generate_receipt
           @messages_in_flight[receipt] = message
           result[receipt] = message

--- a/spec/acceptance/message_actions_spec.rb
+++ b/spec/acceptance/message_actions_spec.rb
@@ -43,6 +43,34 @@ RSpec.describe "Actions for Messages", :sqs do
     expect(response.messages.first.body).to eq body
   end
 
+  specify "ReceiveMessage with visibility_timeout parameter" do
+    body = "test 123"
+
+    sqs.send_message(
+      queue_url: queue_url,
+      message_body: body
+    )
+
+    sqs.receive_message(
+      queue_url: queue_url,
+      visibility_timeout: 0
+    )
+
+    sleep 1
+
+    response = sqs.receive_message(
+      queue_url: queue_url
+    )
+    expect(response.messages.size).to eq 1
+
+    sleep 1
+
+    response = sqs.receive_message(
+      queue_url: queue_url
+    )
+    expect(response.messages.size).to eq 0
+  end
+
   specify "DeleteMessage" do
     sqs.send_message(
       queue_url: queue_url,


### PR DESCRIPTION
- Accept `visibility_timeout` as part of [receive_message call](http://docs.aws.amazon.com/sdkforruby/api/Aws/SQS/Client.html#receive_message-instance_method)
- Decrease the API `run_timer` sleep period from 5 seconds to 1 second
