### PR TITLE
Implement API action ChangeMessageVisibilityBatch

### DIFF
--- a/lib/fake_sqs/actions/change_message_visibility_batch.rb
+++ b/lib/fake_sqs/actions/change_message_visibility_batch.rb
@@ -1,0 +1,37 @@
+module FakeSQS
+  module Actions
+    class ChangeMessageVisibilityBatch
+
+      def initialize(options = {})
+        @queues = options.fetch(:queues)
+        @responder = options.fetch(:responder)
+      end
+
+      def call(queue, params)
+        keys = params.keys.map do |key|
+          case key
+            when /^ChangeMessageVisibilityBatchRequestEntry\.(\w+)\.Id$/
+              $1
+          end
+        end.compact
+
+        messages = keys.map do |key|
+          receipt = params.fetch("ChangeMessageVisibilityBatchRequestEntry.#{key}.ReceiptHandle")
+          timeout = Integer params.fetch("ChangeMessageVisibilityBatchRequestEntry.#{key}.VisibilityTimeout")
+          @queues.get(queue).change_message_visibility(receipt, timeout)
+          params.fetch("ChangeMessageVisibilityBatchRequestEntry.#{key}.Id")
+        end
+
+        @responder.call :ChangeMessageVisibilityBatch do |xml|
+          xml.ChangeMessageVisibilityBatchResult do
+            messages.each do |message|
+              xml.ChangeMessageVisibilityBatchResultEntry do
+                xml.Id message
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fake_sqs/api.rb
+++ b/lib/fake_sqs/api.rb
@@ -1,4 +1,5 @@
 require 'fake_sqs/actions/change_message_visibility'
+require 'fake_sqs/actions/change_message_visibility_batch'
 require 'fake_sqs/actions/create_queue'
 require 'fake_sqs/actions/delete_queue'
 require 'fake_sqs/actions/list_queues'

--- a/spec/acceptance/message_actions_spec.rb
+++ b/spec/acceptance/message_actions_spec.rb
@@ -218,6 +218,8 @@ RSpec.describe "Actions for Messages", :sqs do
     )
     expect(nothing.messages.size).to eq 0
 
+    # Changed from sleep 5 to sleep 7 due to race conditions in Travis build
+    # see https://github.com/iain/fake_sqs/pull/32
     sleep(7)
 
     same_message = sqs.receive_message(

--- a/spec/acceptance/message_actions_spec.rb
+++ b/spec/acceptance/message_actions_spec.rb
@@ -168,6 +168,31 @@ RSpec.describe "Actions for Messages", :sqs do
     expect(same_message.body).to eq body
   end
 
+  specify "set message timeout for batch of messages to 0" do
+    10.times do
+      sqs.send_message(
+        queue_url: queue_url,
+        message_body: "test"
+      )
+    end
+    
+    result = sqs.receive_message(queue_url: queue_url, max_number_of_messages: 10)
+
+    nothing = sqs.receive_message(queue_url: queue_url)
+    expect(nothing.messages.size).to eq 0
+
+
+    sqs.change_message_visibility_batch({
+      queue_url: queue_url,
+      entries: result.messages.map do |message| 
+        {id: message.message_id, receipt_handle: message.receipt_handle, visibility_timeout: 0}
+      end
+    })
+
+    full = sqs.receive_message(queue_url: queue_url, max_number_of_messages: 10)
+    expect(full.messages.size).to eq 10
+  end
+
   specify 'set message timeout and wait for message to come' do
 
     body = 'some-sample-message'

--- a/spec/acceptance/message_actions_spec.rb
+++ b/spec/acceptance/message_actions_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe "Actions for Messages", :sqs do
         message_body: "test"
       )
     end
-    
+
     result = sqs.receive_message(queue_url: queue_url, max_number_of_messages: 10)
 
     nothing = sqs.receive_message(queue_url: queue_url)
@@ -218,7 +218,7 @@ RSpec.describe "Actions for Messages", :sqs do
     )
     expect(nothing.messages.size).to eq 0
 
-    sleep(5)
+    sleep(7)
 
     same_message = sqs.receive_message(
       queue_url: queue_url,


### PR DESCRIPTION
- Implement API action [ChangeMessageVisibilityBatch](http://docs.aws.amazon.com/sdkforruby/api/Aws/SQS/Client.html#change_message_visibility_batch-instance_method)
- Temporary fix for 'wait for message timeout' spec randomly failing

This is an updated version of #9. Since the PR was over a year old, I had to fix the specs.

Also, the Travis build for this commit was randomly failing on the 'wait for message timeout spec', even though my commit didn't have anything to do with this test. I also saw this test failing intermittently on other builds. 

As a temporary fix, I increased the sleep time during the build, however, in the future we may be able to increase spec time and reliability, after merging #31. This will allow us to use a smaller sleep interval and ensure that there is ample time for the `run_timer` to be ran, without sacrificing spec duration.
