### PR TITLE
Implement DLQ (RedrivePolicy) Functionality

### DIFF
--- a/lib/fake_sqs/actions/receive_message.rb
+++ b/lib/fake_sqs/actions/receive_message.rb
@@ -10,6 +10,10 @@ module FakeSQS
 
       def call(name, params)
         queue = @queues.get(name)
+        filtered_attribute_names = []
+        params.select{|k,v | k =~ /AttributeName\.\d+/}.each do |key, value|
+          filtered_attribute_names << value
+        end
         messages = queue.receive_message(params)
         @responder.call :ReceiveMessage do |xml|
           messages.each do |receipt, message|
@@ -18,11 +22,18 @@ module FakeSQS
               xml.ReceiptHandle receipt
               xml.MD5OfBody message.md5
               xml.Body message.body
+              message.attributes.each do |name, value|
+                if filtered_attribute_names.include?("All") || filtered_attribute_names.include?(name)
+                  xml.Attribute do
+                    xml.Name name
+                    xml.Value value
+                  end
+                end
+              end
             end
           end
         end
       end
-
     end
   end
 end

--- a/lib/fake_sqs/actions/receive_message.rb
+++ b/lib/fake_sqs/actions/receive_message.rb
@@ -14,7 +14,7 @@ module FakeSQS
         params.select{|k,v | k =~ /AttributeName\.\d+/}.each do |key, value|
           filtered_attribute_names << value
         end
-        messages = queue.receive_message(params)
+        messages = queue.receive_message(params.merge(queues: @queues))
         @responder.call :ReceiveMessage do |xml|
           messages.each do |receipt, message|
             xml.Message do

--- a/lib/fake_sqs/message.rb
+++ b/lib/fake_sqs/message.rb
@@ -3,17 +3,26 @@ require 'securerandom'
 module FakeSQS
   class Message
 
-    attr_reader :body, :id, :md5
+    attr_reader :body, :id, :md5, :approximate_receive_count, 
+    :sender_id, :approximate_first_receive_timestamp, :sent_timestamp
     attr_accessor :visibility_timeout
 
     def initialize(options = {})
       @body = options.fetch("MessageBody")
       @id = options.fetch("Id") { SecureRandom.uuid }
       @md5 = options.fetch("MD5") { Digest::MD5.hexdigest(@body) }
+      @sender_id = options.fetch("SenderId") { SecureRandom.uuid.delete('-').upcase[0...21] }
+      @approximate_receive_count = 0
+      @sent_timestamp = Time.now.to_i * 1000
     end
 
     def expire!
       self.visibility_timeout = nil
+    end
+
+    def receive!
+      @approximate_first_receive_timestamp ||= Time.now.to_i * 1000
+      @approximate_receive_count += 1
     end
 
     def expired?( limit = Time.now )
@@ -26,9 +35,10 @@ module FakeSQS
 
     def attributes
       {
-        "MessageBody" => body,
-        "Id" => id,
-        "MD5" => md5,
+        "SenderId" => sender_id,
+        "ApproximateFirstReceiveTimestamp" => approximate_first_receive_timestamp,
+        "ApproximateReceiveCount"=> approximate_receive_count,
+        "SentTimestamp"=> sent_timestamp
       }
     end
 

--- a/lib/fake_sqs/queue.rb
+++ b/lib/fake_sqs/queue.rb
@@ -1,6 +1,6 @@
 require 'securerandom'
 require 'fake_sqs/collection_view'
-
+require 'json'
 module FakeSQS
 
   MessageNotInflight = Class.new(RuntimeError)
@@ -45,7 +45,7 @@ module FakeSQS
 
     def send_message(options = {})
       with_lock do
-        message = message_factory.new(options)
+        message = options.fetch(:message){ message_factory.new(options) }
         @messages << message
         message
       end
@@ -65,11 +65,13 @@ module FakeSQS
 
         actual_amount.times do
           message = @messages.delete_at(rand(size))
-          message.expire_at(default_visibility_timeout)
-          message.receive!
-          receipt = generate_receipt
-          @messages_in_flight[receipt] = message
-          result[receipt] = message
+          unless check_message_for_dlq(message, options)
+            message.expire_at(default_visibility_timeout)
+            message.receive!
+            receipt = generate_receipt
+            @messages_in_flight[receipt] = message
+            result[receipt] = message
+          end
         end
       end
 
@@ -113,6 +115,17 @@ module FakeSQS
           message.expire_at(visibility)
         end
 
+      end
+    end
+
+    def check_message_for_dlq(message, options={})
+      if redrive_policy = queue_attributes["RedrivePolicy"] && JSON.parse(queue_attributes["RedrivePolicy"])
+        dlq = options[:queues].list.find{|queue| queue.arn == redrive_policy["deadLetterTargetArn"]}
+        if dlq && message.approximate_receive_count >= redrive_policy["maxReceiveCount"].to_i
+          dlq.send_message(message: message)
+          message.expire!
+          true
+        end
       end
     end
 

--- a/lib/fake_sqs/queue.rb
+++ b/lib/fake_sqs/queue.rb
@@ -66,6 +66,7 @@ module FakeSQS
         actual_amount.times do
           message = @messages.delete_at(rand(size))
           message.expire_at(default_visibility_timeout)
+          message.receive!
           receipt = generate_receipt
           @messages_in_flight[receipt] = message
           result[receipt] = message

--- a/spec/acceptance/message_actions_spec.rb
+++ b/spec/acceptance/message_actions_spec.rb
@@ -234,7 +234,9 @@ RSpec.describe "Actions for Messages", :sqs do
     )
     expect(nothing.messages.size).to eq 0
 
-    sleep(5)
+    # Changed from sleep 5 to sleep 7 due to race conditions in Travis build
+    # see https://github.com/iain/fake_sqs/pull/32
+    sleep(7)
 
     same_message = sqs.receive_message(
       queue_url: queue_url,
@@ -267,6 +269,37 @@ RSpec.describe "Actions for Messages", :sqs do
         visibility_timeout: 30
       )
     }.to raise_error(Aws::SQS::Errors::MessageNotInflight)
+  end
+
+  specify 'should be moved to configured DLQ after maxReceiveCount if RedrivePolicy is set' do
+    dlq_queue_url = sqs.create_queue(queue_name: "TestSourceQueueDLQ").queue_url
+
+    dlq_arn = sqs.get_queue_attributes(queue_url: dlq_queue_url).attributes.fetch("QueueArn")
+    sqs.set_queue_attributes(
+      queue_url: queue_url, 
+      attributes: {
+        "RedrivePolicy" => "{\"deadLetterTargetArn\":\"#{dlq_arn}\",\"maxReceiveCount\":2}"
+      }
+    )
+
+    message_id = sqs.send_message(
+      queue_url: queue_url,
+      message_body: "test",
+    ).message_id
+
+
+    2.times do 
+      message = sqs.receive_message(queue_url: queue_url)
+      expect(message.messages.size).to eq(1)
+      expect(message.messages.first.message_id).to eq(message_id)
+      expire_message(message.messages.first)
+    end
+
+    expect(sqs.receive_message(queue_url: queue_url).messages.size).to eq(0)
+
+    message = sqs.receive_message(queue_url: dlq_queue_url)
+    expect(message.messages.size).to eq(1)
+    expect(message.messages.first.message_id).to eq(message_id)
   end
 
   def let_messages_in_flight_expire

--- a/spec/acceptance/message_actions_spec.rb
+++ b/spec/acceptance/message_actions_spec.rb
@@ -35,12 +35,53 @@ RSpec.describe "Actions for Messages", :sqs do
     )
 
     response = sqs.receive_message(
-      queue_url: queue_url,
+      queue_url: queue_url
     )
 
     expect(response.messages.size).to eq 1
-
     expect(response.messages.first.body).to eq body
+  end
+
+  specify "ReceiveMessage with attribute_names parameters" do
+    body = "test 123"
+
+    sqs.send_message(
+      queue_url: queue_url,
+      message_body: body
+    )
+
+    sent_time = Time.now.to_i * 1000
+
+    response = sqs.receive_message(
+      queue_url: queue_url,
+      attribute_names: ["All"]
+    ) 
+    
+    received_time = Time.now.to_i * 1000
+
+    expect(response.messages.first.attributes.reject{|k,v| k == "SenderId"}).to eq({
+      "SentTimestamp" => sent_time.to_s,
+      "ApproximateReceiveCount" => "1",
+      "ApproximateFirstReceiveTimestamp" => received_time.to_s
+    })
+    expect(response.messages.first.attributes["SenderId"]).to be_kind_of(String)
+    expire_message(response.messages.first)
+
+    response = sqs.receive_message(
+      queue_url: queue_url
+    )
+    expect(response.messages.first.attributes).to eq({})
+    expire_message(response.messages.first)
+
+    response = sqs.receive_message(
+      queue_url: queue_url,
+      attribute_names: ["SentTimestamp", "ApproximateReceiveCount", "ApproximateFirstReceiveTimestamp"]
+    )
+    expect(response.messages.first.attributes).to eq({
+      "SentTimestamp" => sent_time.to_s,
+      "ApproximateReceiveCount" => "3",
+      "ApproximateFirstReceiveTimestamp" => received_time.to_s
+    })
   end
 
   specify "DeleteMessage" do
@@ -230,6 +271,14 @@ RSpec.describe "Actions for Messages", :sqs do
 
   def let_messages_in_flight_expire
     $fake_sqs.expire
+  end
+
+  def expire_message(message)
+    sqs.change_message_visibility(
+      queue_url: queue_url,
+      receipt_handle: message.receipt_handle,
+      visibility_timeout: 0
+    )
   end
 
 end


### PR DESCRIPTION
- Implement [DLQ (RedrivePolicy) Functionality](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQSDeadLetterQueue.html)

This will demonstrate the actual functionality of moving a message to a configured DLQ after being received the configured `Maximum Receives`.

This commit was made on top of #30, due to the requirement of `approximate_receive_count` of the `Message` to ascertain DLQ eligibility.
