### PR TITLE
Added support for controlling the hostname in generted Queue URLs via `--host` parameter.

### DIFF
--- a/bin/fake_sqs
+++ b/bin/fake_sqs
@@ -8,7 +8,8 @@ require 'optparse'
 
 options = {
   :port => 4568,
-  :host => "0.0.0.0",
+  :bind => "0.0.0.0",
+  :host => "localhost",
   :verbose => false,
   :daemonize => false,
   :database => ":memory:"
@@ -24,7 +25,11 @@ parser = OptionParser.new do |o|
     options[:port] = port
   end
 
-  o.on "-o", "--bind HOST", "Host to bind to (default: #{options[:host]})" do |host|
+  o.on "-o", "--bind HOST", "Host to bind to (default: #{options[:bind]})" do |bind|
+    options[:bind] = bind
+  end
+
+  o.on "-o", "--host HOST", "Host for generated Queue URLs (default: #{options[:host]})" do |host|
     options[:host] = host
   end
 

--- a/lib/fake_sqs.rb
+++ b/lib/fake_sqs.rb
@@ -39,7 +39,7 @@ module FakeSQS
     end
 
     app.set :port, options[:port] if options[:port]
-    app.set :bind, options[:host] if options[:host]
+    app.set :bind, options[:bind] if options[:bind]
     app.set :server, options[:server] if options[:server]
     server = FakeSQS.server(port: options[:port], host: options[:host])
     app.set :api, FakeSQS.api(server: server, database: options[:database])

--- a/spec/acceptance/queue_actions_spec.rb
+++ b/spec/acceptance/queue_actions_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Actions for Queues", :sqs do
 
   specify "CreateQueue" do
     response = sqs.create_queue(queue_name: "test-create-queue")
-    expect(response.queue_url).to eq "http://0.0.0.0:4568/test-create-queue"
+    expect(response.queue_url).to eq "http://localhost:4568/test-create-queue"
     response2 = sqs.get_queue_attributes(queue_url: response.queue_url)
     expect(response2.attributes.fetch("QueueArn")).to match %r"arn:aws:sqs:us-east-1:.+:test-create-queue"
   end
@@ -17,15 +17,15 @@ RSpec.describe "Actions for Queues", :sqs do
   specify "GetQueueUrl" do
     sqs.create_queue(queue_name: "test-get-queue-url")
     response = sqs.get_queue_url(queue_name: "test-get-queue-url")
-    expect(response.queue_url).to eq "http://0.0.0.0:4568/test-get-queue-url"
+    expect(response.queue_url).to eq "http://localhost:4568/test-get-queue-url"
   end
 
   specify "ListQueues" do
     sqs.create_queue(queue_name: "test-list-1")
     sqs.create_queue(queue_name: "test-list-2")
     expect(sqs.list_queues.queue_urls).to eq [
-      "http://0.0.0.0:4568/test-list-1",
-      "http://0.0.0.0:4568/test-list-2"
+      "http://localhost:4568/test-list-1",
+      "http://localhost:4568/test-list-2"
     ]
   end
 
@@ -34,8 +34,8 @@ RSpec.describe "Actions for Queues", :sqs do
     sqs.create_queue(queue_name: "test-list-2")
     sqs.create_queue(queue_name: "other-list-3")
     expect(sqs.list_queues(queue_name_prefix: "test").queue_urls).to eq [
-      "http://0.0.0.0:4568/test-list-1",
-      "http://0.0.0.0:4568/test-list-2",
+      "http://localhost:4568/test-list-1",
+      "http://localhost:4568/test-list-2",
     ]
   end
 


### PR DESCRIPTION
This PR basically makes --bind control the IP to connect to and leaves --host to control the hostname part of the generated Queue URL strings.
