### PR TITLE
Broken DeleteMessage and DeleteMessageBatch

### DIFF
--- a/lib/fake_sqs/databases/file.rb
+++ b/lib/fake_sqs/databases/file.rb
@@ -56,6 +56,7 @@ module FakeSQS
     end
 
     def delete(key)
+      @queue_objects.delete(key)
       storage.delete(key)
     end
 

--- a/lib/fake_sqs/helper.rb
+++ b/lib/fake_sqs/helper.rb
@@ -1,0 +1,12 @@
+require 'sinatra/base'
+
+module FakeSQS
+  class Helper
+
+    def queue_from_url(queue_url)
+      uri = URI.parse(queue_url)
+      return uri.path.tr('/', '')
+    end
+
+  end
+end

--- a/lib/fake_sqs/message.rb
+++ b/lib/fake_sqs/message.rb
@@ -1,4 +1,5 @@
 require 'securerandom'
+require 'digest/sha1'
 
 module FakeSQS
   class Message
@@ -50,6 +51,10 @@ module FakeSQS
         "ApproximateReceiveCount"=> approximate_receive_count,
         "SentTimestamp"=> sent_timestamp
       }
+    end
+
+    def receipt
+      Digest::SHA1.hexdigest self.id
     end
 
   end

--- a/lib/fake_sqs/queue.rb
+++ b/lib/fake_sqs/queue.rb
@@ -151,7 +151,8 @@ module FakeSQS
 
     def expire
       with_lock do
-        @messages_in_flight.merge!(@messages)
+        @messages.merge!(@messages_in_flight)
+        @messages_in_flight.clear()
         reset_messages_in_flight
       end
     end

--- a/lib/fake_sqs/test_integration.rb
+++ b/lib/fake_sqs/test_integration.rb
@@ -75,7 +75,7 @@ module FakeSQS
     end
 
     def verbose
-      if debug?
+      if options[:verbose]
         "--verbose"
       else
         "--no-verbose"

--- a/lib/fake_sqs/web_interface.rb
+++ b/lib/fake_sqs/web_interface.rb
@@ -1,4 +1,5 @@
 require 'sinatra/base'
+require 'fake_sqs/helper'
 require 'fake_sqs/catch_errors'
 require 'fake_sqs/error_response'
 
@@ -37,15 +38,15 @@ module FakeSQS
 
     handle "/", [:get, :post] do
       if params['QueueUrl']
-        queue = URI.parse(params['QueueUrl']).path.gsub(/\//, '')
-        return settings.api.call(action, request, queue, params) unless queue.empty?
+        queue_name = Helper::queue_from_url(params['QueueUrl'])
+        return settings.api.call(action, request, queue_name, params) unless queue_name.empty?
       end
 
       settings.api.call(action, request, params)
     end
 
-    handle "/:queue", [:get, :post] do |queue|
-      settings.api.call(action, request, queue, params)
+    handle "/:queue_name", [:get, :post] do |queue_name|
+      settings.api.call(action, request, queue_name, params)
     end
   end
 end

--- a/spec/acceptance/message_actions_spec.rb
+++ b/spec/acceptance/message_actions_spec.rb
@@ -91,10 +91,9 @@ RSpec.describe "Actions for Messages", :sqs do
 
     message1 = sqs.receive_message(
       queue_url: queue_url,
-      visibility_timeout: 0,
     ).messages.first
 
-    sleep(1)
+    let_messages_in_flight_expire
 
     sqs.delete_message(
       queue_url: queue_url,
@@ -120,11 +119,10 @@ RSpec.describe "Actions for Messages", :sqs do
     messages_response = sqs.receive_message(
       queue_url: queue_url,
       max_number_of_messages: 2,
-      visibility_timeout: 0,
     )
     expect(messages_response.messages.size).to eq 2
 
-    sleep(1)
+    let_messages_in_flight_expire
 
     response = sqs.delete_message_batch(
       queue_url: queue_url,
@@ -137,12 +135,9 @@ RSpec.describe "Actions for Messages", :sqs do
     )
     expect(response.successful.size).to eq(2)
 
-    sleep(1)
-
     messages_response = sqs.receive_message(
       queue_url: queue_url,
       max_number_of_messages: 2,
-      visibility_timeout: 0,
     )
     expect(messages_response.messages.size).to eq 0
   end
@@ -168,7 +163,7 @@ RSpec.describe "Actions for Messages", :sqs do
   end
 
   specify "DeleteQueue" do
-    sqs.send_message(
+    sent_message = sqs.send_message(
       queue_url: queue_url,
       message_body: "test1"
     )
@@ -176,7 +171,10 @@ RSpec.describe "Actions for Messages", :sqs do
     response = sqs.receive_message(
       queue_url: queue_url,
     )
+    expect(response.messages[0].message_id).to eq sent_message.message_id
     expect(response.messages.size).to eq 1
+
+    let_messages_in_flight_expire
 
     sqs.delete_queue(queue_url: queue_url)
     sqs.create_queue(queue_name: QUEUE_NAME)
@@ -199,14 +197,12 @@ RSpec.describe "Actions for Messages", :sqs do
         }
       }
     )
-
     expect(response.successful.size).to eq(3)
 
     messages_response = sqs.receive_message(
       queue_url: queue_url,
       max_number_of_messages: 3,
     )
-
     expect(messages_response.messages.map(&:body)).to match_array bodies
   end
 
@@ -220,14 +216,14 @@ RSpec.describe "Actions for Messages", :sqs do
 
     message = sqs.receive_message(
       queue_url: queue_url,
+      visibility_timeout: 10,
     ).messages.first
-
     expect(message.body).to eq body
 
     sqs.change_message_visibility(
       queue_url: queue_url,
       receipt_handle: message.receipt_handle,
-      visibility_timeout: 0
+      visibility_timeout: 0,
     )
 
     same_message = sqs.receive_message(
@@ -246,13 +242,14 @@ RSpec.describe "Actions for Messages", :sqs do
 
     message = sqs.receive_message(
       queue_url: queue_url,
+      visibility_timeout: 10,
     ).messages.first
     expect(message.body).to eq body
 
     sqs.change_message_visibility(
       queue_url: queue_url,
       receipt_handle: message.receipt_handle,
-      visibility_timeout: 1
+      visibility_timeout: 1,
     )
 
     nothing = sqs.receive_message(
@@ -269,27 +266,15 @@ RSpec.describe "Actions for Messages", :sqs do
   end
 
   specify 'should fail if trying to update the visibility_timeout for a message that is not in flight' do
-    body = 'some-sample-message'
-    sqs.send_message(
+    response = sqs.send_message(
       queue_url: queue_url,
-      message_body: body,
-    )
-
-    message = sqs.receive_message(
-      queue_url: queue_url,
-    ).messages.first
-    expect(message.body).to eq body
-
-    sqs.change_message_visibility(
-      queue_url: queue_url,
-      receipt_handle: message.receipt_handle,
-      visibility_timeout: 0
+      message_body: 'some-sample-message',
     )
 
     expect {
       sqs.change_message_visibility(
         queue_url: queue_url,
-        receipt_handle: message.receipt_handle,
+        receipt_handle: response.message_id,
         visibility_timeout: 30
       )
     }.to raise_error(Aws::SQS::Errors::MessageNotInflight)
@@ -311,7 +296,7 @@ RSpec.describe "Actions for Messages", :sqs do
     message = sqs.receive_message(
       queue_url: queue_url,
       max_number_of_messages: 10,
-      visibility_timeout: 0,
+      visibility_timeout: 1,
     )
     expect(message.messages.size).to eq(10)
 
@@ -326,6 +311,8 @@ RSpec.describe "Actions for Messages", :sqs do
       }
     )
     expect(response.successful.size).to eq(10)
+
+    sleep(2)
 
     message = sqs.receive_message(
       queue_url: queue_url,
@@ -373,7 +360,7 @@ RSpec.describe "Actions for Messages", :sqs do
     sqs.change_message_visibility(
       queue_url: queue_url,
       receipt_handle: message.receipt_handle,
-      visibility_timeout: 0
+      visibility_timeout: 0,
     )
   end
 

--- a/spec/acceptance/message_actions_spec.rb
+++ b/spec/acceptance/message_actions_spec.rb
@@ -91,14 +91,15 @@ RSpec.describe "Actions for Messages", :sqs do
 
     message1 = sqs.receive_message(
       queue_url: queue_url,
+      visibility_timeout: 0,
     ).messages.first
+
+    sleep(1)
 
     sqs.delete_message(
       queue_url: queue_url,
       receipt_handle: message1.receipt_handle,
     )
-
-    let_messages_in_flight_expire
 
     response = sqs.receive_message(
       queue_url: queue_url,
@@ -123,7 +124,7 @@ RSpec.describe "Actions for Messages", :sqs do
     )
     expect(messages_response.messages.size).to eq 2
 
-    let_messages_in_flight_expire
+    sleep(1)
 
     response = sqs.delete_message_batch(
       queue_url: queue_url,
@@ -136,7 +137,7 @@ RSpec.describe "Actions for Messages", :sqs do
     )
     expect(response.successful.size).to eq(2)
 
-    let_messages_in_flight_expire
+    sleep(1)
 
     messages_response = sqs.receive_message(
       queue_url: queue_url,


### PR DESCRIPTION
Something seems to be funky with DeleteMessage and DeleteMessageBatch. Both functions require the message to be in-flight to work. Not really sure if this is intended.

Amazon documentation for DeleteMessage:
http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_DeleteMessage.html