### PR TITLE
support for long polling (WaitTimeSeconds)

### DIFF
--- a/lib/fake_sqs/actions/receive_message.rb
+++ b/lib/fake_sqs/actions/receive_message.rb
@@ -8,7 +8,7 @@ module FakeSQS
         @server    = options.fetch(:server)
         @queues    = options.fetch(:queues)
         @responder = options.fetch(:responder)
-        @start_ts  = Time.now.to_i
+        @start_ts  = Time.now.to_f
         @satisfied = false
       end
 
@@ -46,7 +46,7 @@ module FakeSQS
 
       protected
       def elapsed
-        Time.now.to_i - @start_ts
+        Time.now.to_f - @start_ts
       end
 
       def expired?(queue, params)

--- a/lib/fake_sqs/actions/receive_message.rb
+++ b/lib/fake_sqs/actions/receive_message.rb
@@ -2,10 +2,14 @@ module FakeSQS
   module Actions
     class ReceiveMessage
 
+      MAX_WAIT_TIME_SECONDS = 20
+
       def initialize(options = {})
         @server    = options.fetch(:server)
         @queues    = options.fetch(:queues)
         @responder = options.fetch(:responder)
+        @start_ts  = Time.now.to_i
+        @satisfied = false
       end
 
       def call(queue_name, params)
@@ -15,6 +19,7 @@ module FakeSQS
           filtered_attribute_names << value
         end
         messages = queue.receive_message(params.merge(queues: @queues))
+        @satisfied = !messages.empty? || expired?(queue, params)
         @responder.call :ReceiveMessage do |xml|
           messages.each do |receipt, message|
             xml.Message do
@@ -33,6 +38,24 @@ module FakeSQS
             end
           end
         end
+      end
+
+      def satisfied?
+        @satisfied
+      end
+
+      protected
+      def elapsed
+        Time.now.to_i - @start_ts
+      end
+
+      def expired?(queue, params)
+        wait_time_seconds = Integer params.fetch("WaitTimeSeconds") {
+          queue.queue_attributes.fetch("ReceiveMessageWaitTimeSeconds") { 0 }
+        }
+        wait_time_seconds <= 0 ||
+        elapsed >= wait_time_seconds ||
+        elapsed >= MAX_WAIT_TIME_SECONDS
       end
     end
   end


### PR DESCRIPTION
fixes #22 

allow a ReceiveMessage action to know whether an attempt (via call)
"satisified" the request, and then have the dispatcher in the API loop
until it is satisfied, sleeping in between, rather than just making one
attempt.

the ReceiveMessage action is "satisfied" by either return 1+ results, or
by expiring. it expires according to the action's WaitTimeSeconds or the
queue's ReceiveMessageWaitTimeSeconds. if neither is set, or is set to
0, then only one attempt is made before immediately expiring.

I intend to add another commit with specs for the new behavior, but want to trigger the CI build to compare it with #56, since I can't replicate its failures locally.